### PR TITLE
Add additional URLs for package information and bug reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,8 @@ Imports:
     stringr
 License: GPL-3 | file LICENSE
 Description: The Predictive Model Markup Language (PMML) is an XML-based language which provides a way for applications to define machine learning, statistical and data mining models and to share models between PMML compliant applications. More information about the PMML industry standard and the Data Mining Group can be found at <http://www.dmg.org>. The generated PMML can be imported into any PMML consuming application, such as Zementis Predictive Analytics products, which integrate with web services, relational database systems and deploy natively on Hadoop in conjunction with Hive, Spark or Storm, as well as allow predictive analytics to be executed for IBM z Systems mainframe applications and real-time, streaming analytics platforms. The package isofor (used for anomaly detection) can be installed with devtools::install_github("Zelazny7/isofor").
-URL: https://www.softwareag.com/zementis
+URL: https://softwareag.github.io/r-pmml/, https://github.com/SoftwareAG/r-pmml, https://www.softwareag.com/zementis
+BugReports: https://github.com/SoftwareAG/r-pmml/issues
 NeedsCompilation: no
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr


### PR DESCRIPTION
Add missing URLs so that CRAN users, for instance, can find the necessary information in the package documentation on how to submit bug reports. 