### PR TITLE
Parallelize random Forest to PMML conversion

### DIFF
--- a/R/pmml.randomForest.R
+++ b/R/pmml.randomForest.R
@@ -160,9 +160,9 @@ pmml.randomForest <- function(model,
   }
 
   numTrees <- model$ntree
-  segments <- lapply(1:numTrees, function(x) {
+  segments <- foreach(x=1:numTrees) %dopar% {
     .makeSegment(x, model, model_name, field, target, missing_value_replacement, child_invalid_value_treatment)
-  })
+  }
   segmentation2 <- append.XMLNode(segmentation, segments)
   rm(segmentation)
   rm(segments)


### PR DESCRIPTION
Just added the foreach loop with %dopar%, instead of lapply, so that it can parallelize when used with parallel backend runtimes of R. As an example, for my problem, Random forest with 200 trees was able to run in under 3 minutes, instead of the original 8-9 minutes. One dropback might be that you might not be able to see the message posted by the parallel process, depending on the different parallel backends.